### PR TITLE
fix static file path error

### DIFF
--- a/views/layout.slim
+++ b/views/layout.slim
@@ -7,7 +7,8 @@ html
     meta content="" name="description"
     meta content="" name="author"
     link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css"
-    link rel='stylesheet' type='text/css' href="css/style.css"
+    link rel='stylesheet' type='text/css' href="/css/style.css"
+    base href="{{ baseURL }}"
     title Smartibuy!
   body
     == slim :nav


### PR DESCRIPTION
Note that

```
link rel='stylesheet' type='text/css' href="css/style.css"
# it will work if the link is http://hostname/group/, but not work http://hostname/group/group_id
# if the link is http://hostname/group/group_id, the slim will lookup css file under group/css/
```

so the `href` should be

```
link rel='stylesheet' type='text/css' href="/css/style.css"
```

it will work in the right way.
